### PR TITLE
Set ACLs on the Switchboard data directory

### DIFF
--- a/backoffice.yaml
+++ b/backoffice.yaml
@@ -11,6 +11,7 @@
     - import_tasks: tasks/systemd.yaml
     - import_tasks: tasks/prometheus.yaml
     - import_tasks: tasks/uwsgi.yaml
+    - import_tasks: tasks/switchboard.yaml
 
   handlers:
     - name: prometheus is restarted

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,5 +1,8 @@
 ---
 collections:
+  - name: ansible.posix
+    version: 1.1.1
+
   - name: community.general
     version: 1.3.0
 

--- a/tasks/switchboard.yaml
+++ b/tasks/switchboard.yaml
@@ -1,0 +1,31 @@
+---
+- name: switchboard data dir owner/group/mode is set
+  file:
+    path: &data_dir /opt/scan-switchboard/data
+    owner: "{{app_user}}"
+    group: "{{app_user}}"
+    mode: ug=rwx,o=rx
+    state: directory
+
+- name: switchboard data dir ACLs are set
+  loop:
+    - "{{app_user}}"
+    - nobody
+  ansible.posix.acl:
+    path: *data_dir
+    etype: user
+    entity: "{{item}}"
+    permissions: rwx
+    state: present
+
+- name: switchboard data dir default ACLs are set
+  loop:
+    - "{{app_user}}"
+    - nobody
+  ansible.posix.acl:
+    path: *data_dir
+    default: true
+    etype: user
+    entity: "{{item}}"
+    permissions: rwX
+    state: present


### PR DESCRIPTION
We're enabling journal_mode=wal on the SQLite database for better
concurrency, but this means that Switchboard's web app now needs write
access to create and update the sidecar files used by SQLite for its WAL.

As the data updating cronjob runs as ubuntu and the data serving web app
runs as nobody, this access is easiest managed via ACLs instead of
standard owner/group perms.  (The alternative is creating a group to put
both users into and making files owned by that group.)

The expectation is that the rest of Switchboard's deployment will
eventually be managed via Ansible as well.  This is just a toehold.