### PR TITLE
prometheus: Update metrics more often

### DIFF
--- a/files/etc/prometheus/prometheus.yml
+++ b/files/etc/prometheus/prometheus.yml
@@ -1,5 +1,9 @@
 # {{ansible_managed}}
 
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
 scrape_configs:
   # Metrics about the prometheus server itself
   - job_name: prometheus


### PR DESCRIPTION
The default interval is 1 min, which is too slow to see events that
happen within that resolution.  For example, we've had out-of-memory
events where the usage quickly spikes, the oom-killer comes out to play,
and the usage drops, all within 1 min.

Scraping every 15s seems to be a configuration used pretty widely.
Recommended values are in the 10-60s range¹, so we've moved from one side
of that to the other.  The default timeout of 10s is left as-is, since
it's been working ok, but made explicit now that we're closer to it.  It
should still prevent hanging scrapes and scrape overlaps.

¹ Several sources recommend this, but my most trusted source is
  <https://www.robustperception.io/keep-it-simple-scrape_interval-id>.