### PR TITLE
trs/wip/deploy

### DIFF
--- a/backoffice.yaml
+++ b/backoffice.yaml
@@ -12,6 +12,8 @@
 
   tasks:
     - import_tasks: tasks/apt-update.yaml
+    - import_tasks: tasks/python.yaml
+    - import_tasks: tasks/source.yaml
     - import_tasks: tasks/systemd.yaml
     - import_tasks: tasks/prometheus.yaml
     - import_tasks: tasks/uwsgi.yaml
@@ -31,6 +33,18 @@
     - name: prometheus is reloaded
       service:
         name: prometheus
+        state: reloaded
+
+    - name: uwsgi apps are restarted
+      loop: "{{ uwsgi_apps }}"
+      service:
+        name: "uwsgi@{{ item }}"
+        state: restarted
+
+    - name: uwsgi apps are reloaded
+      loop: "{{ uwsgi_apps }}"
+      service:
+        name: "uwsgi@{{ item }}"
         state: reloaded
 
     - name: promtail is restarted

--- a/tasks/python.yaml
+++ b/tasks/python.yaml
@@ -1,0 +1,19 @@
+---
+- name: python basics are installed
+  apt:
+    package:
+      - python3
+      - python3-dev
+      - python3-pip
+      - python3-venv
+
+- name: pipenv is installed
+  pip:
+    name:
+      - pipenv==2018.11.26
+
+- name: pipenv is configured
+  lineinfile:
+    path: /etc/environment
+    regexp: '^PIPENV_VENV_IN_PROJECT='
+    line: 'PIPENV_VENV_IN_PROJECT=1'

--- a/tasks/source.yaml
+++ b/tasks/source.yaml
@@ -1,0 +1,25 @@
+---
+- name: "/opt/backoffice is owned by {{app_user}}"
+  file:
+    path: /opt/backoffice
+    state: directory
+    owner: "{{app_user}}"
+    group: "{{app_user}}"
+
+- name: /opt/backoffice is up-to-date
+  git:
+    repo: https://github.com/seattleflu/backoffice
+    dest: /opt/backoffice
+  become: no
+
+- name: os deps are installed
+  apt:
+    package:
+      - libpq-dev
+      - postgresql-client-10
+
+- name: id3c-production deps are installed
+  shell:
+    chdir: /opt/backoffice/id3c-production
+    cmd: PIPENV_VENV_IN_PROJECT=1 pipenv sync
+  become: no

--- a/tasks/uwsgi.yaml
+++ b/tasks/uwsgi.yaml
@@ -5,6 +5,11 @@
       - uwsgi
       - uwsgi-plugin-python3
 
+- name: default uwsgi multi-app service is disabled
+  service:
+    name: uwsgi
+    enabled: no
+    state: stopped
 
 - name: uwsgi base config exists
   copy:
@@ -13,6 +18,8 @@
     owner: root
     group: root
     mode: ugo=r
+  notify:
+    - uwsgi apps are reloaded
 
 - name: uwsgi app configs exists
   loop: "{{ uwsgi_apps }}"
@@ -22,6 +29,8 @@
     owner: root
     group: root
     mode: ugo=r
+  notify:
+    - uwsgi apps are reloaded
 
 - name: uwsgi app logs readable by adm group
   file:
@@ -39,3 +48,24 @@
     owner: root
     group: adm
     mode: u=rwx,go=rxs
+
+- name: uwsgi apps are enabled
+  loop: "{{uwsgi_apps}}"
+  service:
+    name: "uwsgi@{{item}}"
+    enabled: yes
+    state: started
+
+- name: uwsgi apps are enabled
+  loop: "{{uwsgi_apps}}"
+  service:
+    name: "uwsgi@{{item}}"
+    enabled: yes
+    state: started
+
+- name: uwsgi prometheus exporters are enabled
+  loop: "{{uwsgi_apps}}"
+  service:
+    name: "prometheus-uwsgi-exporter@{{item}}"
+    enabled: yes
+    state: started


### PR DESCRIPTION
Automate deployments

To do this, I think we need to bring in a lot more of the deployment
process (which is our longer-term goal anyway).

I'm 50% sure the organization of tasks into tasks/source.yaml isn't the
right factoring for deploys.  I'm 90% sure that the bits in
tasks/uwsgi.yaml, tasks/python.yaml, and other files are a good
factoring, though.

Todos:

  - Merge in backoffice.git into this repo, with contents under a subdir
    (for now), while preserving git history. This will let files in there be
    managed/installed by Ansible instead of by running git pull on
    backoffice.

  - Port and adapt documented deploy steps into idempotent tasks in one
    or more Ansible playbooks.

  - Bring Apache and Shibboleth management under the wings of Ansible
    too. I would expect to merge in backoffice-apache2.git and
    backoffice-shibboleth.git into this repo too, along similar lines to
    (1).

There's a continuum here though, and each item above can be split into
separate, iterative steps that rachet towards the goal. That said,
upfront time aside, it might be easier to do things in one fell swoop to
reduce the overhead of coordinating changes.

The WIP here adds management of uWSGI apps, but it alone is not
sufficient for managing deploys.