### PR TITLE
Rename Internal SCAN Switchboard Mentions to SFS Switchboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,24 @@ inventory (*hosts/development*).  You should see green text saying something lik
 
     backoffice.multipass | SUCCESS => {
         "ping": "pong",
+
+    }
+
+If Ansible cannot login and you recieve a message like:
+
+    backoffice.multipass | UNREACHABLE! => {
+        "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname backoffice.multipass: nodename nor servname provided, or not known",
         …
     }
 
-For troubleshooting, you can get a shell on your new instance at any point
+Then you should try running
+
+    multipass info backoffice
+
+and use the IPv4 address printed out in lieu of the hostname provided in *hosts/development*
+
+
+For other troubleshooting, you can get a shell on your new instance at any point
 with:
 
     multipass shell backoffice

--- a/tasks/switchboard.yaml
+++ b/tasks/switchboard.yaml
@@ -1,7 +1,7 @@
 ---
 - name: switchboard data dir owner/group/mode is set
   file:
-    path: &data_dir /opt/scan-switchboard/data
+    path: &data_dir /opt/sfs-switchboard/data
     owner: "{{app_user}}"
     group: "{{app_user}}"
     mode: ug=rwx,o=rx


### PR DESCRIPTION
The SCAN Switchboard is now being called the SFS Switchboard, this change updates the directory name to match this name change