### PR TITLE
Ignore Docker Locations for Prometheus Node Exporter

### DIFF
--- a/backoffice.yaml
+++ b/backoffice.yaml
@@ -44,6 +44,11 @@
         name: prometheus
         state: reloaded
 
+    - name: prometheus-node-exporter is restarted
+      service:
+        name: prometheus-node-exporter
+        state: restarted
+
     - name: promtail is restarted
       service:
         name: promtail

--- a/tasks/prometheus.yaml
+++ b/tasks/prometheus.yaml
@@ -48,6 +48,19 @@
   notify:
     - prometheus is reloaded
 
+- name: prometheus-node-exporter invocation is configured
+  replace:
+    path: /etc/default/prometheus-node-exporter
+    regexp: '(?ms)^ARGS=".+?"$'
+    replace: |-
+      ARGS="--collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$ \
+            --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run|var\/lib\/docker\/containers\/.*\/mounts\/shm|var\/lib\/docker\/overlay2\/.*\/merged)($|/) \
+            --collector.netdev.ignored-devices=^lo$ \
+            --collector.textfile.directory=/var/lib/prometheus/node-exporter \
+            --collector.systemd"
+  notify:
+    - prometheus-node-exporter is restarted
+
 - name: prometheus-textfile group exists
   group:
     name: prometheus-textfile
@@ -92,4 +105,3 @@
     name: prometheus-apache-exporter
     enabled: yes
     state: started
-

--- a/tasks/prometheus.yaml
+++ b/tasks/prometheus.yaml
@@ -53,7 +53,7 @@
     path: /etc/default/prometheus-node-exporter
     regexp: '(?ms)^ARGS=".+?"$'
     replace: |-
-      ARGS="--collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$ \
+      ARGS="--collector.diskstats.ignored-devices=(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\\\\\\\dn\\\\\\\\d?p?)\\\\\\\\d+ \
             --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run|var\/lib\/docker\/containers\/.*\/mounts\/shm|var\/lib\/docker\/overlay2\/.*\/merged)($|/) \
             --collector.netdev.ignored-devices=^lo$ \
             --collector.textfile.directory=/var/lib/prometheus/node-exporter \


### PR DESCRIPTION
The prometheus node exporter was trying to scrape logs from docker directories that it
did not have permissions to access. This change adds a step in the backoffice distribution
that will make this alteration automatically.