### PR TITLE
Scrape Musher Structured Logs

### DIFF
--- a/files/etc/promtail/promtail.yml
+++ b/files/etc/promtail/promtail.yml
@@ -43,7 +43,7 @@ scrape_configs:
           job: uwsgi
           app: api-testing
       - labels:
-          __path__: /var/log/uwsgi/app/husky-musher.log
+          __path__: /var/log/husky_musher/husky-musher.log
           job: uwsgi
           app: husky-musher
 


### PR DESCRIPTION
We are turning on Musher Structured Logs, which will need to be scraped. This change
adds the directory from which to scrape these logs to the promtail set up.