### PR TITLE
Bugfix: Run uWSGI systemd apps with binary from python path

### DIFF
--- a/files/etc/systemd/system/uwsgi@.service
+++ b/files/etc/systemd/system/uwsgi@.service
@@ -8,7 +8,7 @@ Wants=network-online.target
 Wants=prometheus-uwsgi-exporter@%i.service
 
 [Service]
-ExecStart=/usr/bin/uwsgi --ini /etc/uwsgi/base.ini --ini /etc/uwsgi/apps-available/%i.ini
+ExecStart=/opt/python/current/bin/uwsgi --ini /etc/uwsgi/base.ini --ini /etc/uwsgi/apps-available/%i.ini
 ExecReload=/bin/kill -HUP $MAINPID
 RuntimeDirectory=uwsgi/app/%i
 # Newer versions of systemd export RUNTIME_DIRECTORY automatically, but not the


### PR DESCRIPTION
Ubuntu 18.04 uses a version of uWSGI (2.0.15-debian)
that's compatible with python 3.6, but not with 3.9.10,
which we've since upgraded to. Instead, lets use the
uWSGI binary from the current python directory, which is
version 2.0.20 .

Co-authored-by: Ben Capodanno <capodb@uw.edu>